### PR TITLE
Added support for Swedish eID specific MDSL attribute

### DIFF
--- a/opensaml3/pom.xml
+++ b/opensaml3/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.litsec.eidas</groupId>
   <artifactId>eidas-opensaml3</artifactId>
   <packaging>jar</packaging>
-  <version>1.3.2</version>
+  <version>1.3.3-SNAPSHOT</version>
 
   <name>eIDAS :: OpenSAML 3.X</name>
   <description>OpenSAML 3.X extension library for the eIDAS Framework</description>

--- a/opensaml3/src/main/java/se/litsec/eidas/opensaml/metadata/Endpoint.java
+++ b/opensaml3/src/main/java/se/litsec/eidas/opensaml/metadata/Endpoint.java
@@ -118,20 +118,38 @@ public interface Endpoint extends SAMLObject, AttributeExtensibleXMLObject {
   void setEntityID(String entityID);
 
   /**
-   * For the Swedish eIDAS configuration, a flag, {@code Suspend} is used to indicate whether an endpoint has been
-   * suspended. This method is just a short cut instead of using {@link #getUnknownAttributes()}.
+   * For the Swedish eIDAS configuration, the {@code Suspend} attribute is used to indicate whether an endpoint has been
+   * suspended. This method is just a shortcut instead of using {@link #getUnknownAttributes()}.
    * 
-   * @return if the {@code Suspend} flag has been set to {@code true} this method returns {@code true}, otherwise
+   * @return if the {@code Suspend} attribute has been set to {@code true} this method returns {@code true}, otherwise
    *         {@code false} 
    */
   boolean getSuspend();
 
   /**
-   * Assigns the {@code Suspend} flag. See {@link #getSuspend()}.
+   * Assigns the {@code Suspend} attribute. See {@link #getSuspend()}.
    * 
    * @param suspendFlag
    *          the suspend flag
    */
   void setSuspend(boolean suspendFlag);
+
+  /**
+   * For the Swedish eIDAS configuration, the {@code HideFromDiscovery} attribute is used to indicate whether the proxy
+   * service within an endpoint should be hidden from the connector "select country view". This method is just a
+   * shortcut instead of using {@link #getUnknownAttributes()}.
+   * 
+   * @return if the {@code HideFromDiscovery} attribute has been set to {@code true} this method returns {@code true},
+   *         otherwise {@code false}
+   */
+  boolean getHideFromDiscovery();
+
+  /**
+   * Assigns the {@code HideFromDiscovery} attribute. See {@link #getHideFromDiscovery()}.
+   * 
+   * @param hideFlag
+   *          the "HideFromDiscovery" flag
+   */
+  void setHideFromDiscovery(boolean hideFlag);
 
 }

--- a/opensaml3/src/main/java/se/litsec/eidas/opensaml/metadata/impl/EndpointImpl.java
+++ b/opensaml3/src/main/java/se/litsec/eidas/opensaml/metadata/impl/EndpointImpl.java
@@ -42,7 +42,11 @@ public class EndpointImpl extends AbstractSAMLObject implements Endpoint {
   /** The entityID. */
   private String entityID;
   
+  /** The name for the Suspend attribute. */
   private static final QName suspendQname = new QName("Suspend");
+  
+  /** The name for the HideFromDiscovery attribute. */
+  private static final QName hideFromDiscoveryQname = new QName("HideFromDiscovery");
 
   /**
    * Constructor.
@@ -102,6 +106,19 @@ public class EndpointImpl extends AbstractSAMLObject implements Endpoint {
     this.unknownAttributes.put(suspendQname, XSBooleanValue.toString(suspendFlag, false));
   }
   
+  /** {@inheritDoc} */
+  @Override
+  public boolean getHideFromDiscovery() {
+    String v = this.unknownAttributes.getOrDefault(hideFromDiscoveryQname, XSBooleanValue.toString(false, false));
+    return XSBooleanValue.valueOf(v).getValue();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setHideFromDiscovery(boolean hideFlag) {
+    this.unknownAttributes.put(hideFromDiscoveryQname, XSBooleanValue.toString(hideFlag, false));
+  }
+
   @Override
   public AttributeMap getUnknownAttributes() {
     return this.unknownAttributes;

--- a/opensaml3/src/test/java/se/litsec/eidas/opensaml/metadata/EndpointTest.java
+++ b/opensaml3/src/test/java/se/litsec/eidas/opensaml/metadata/EndpointTest.java
@@ -78,6 +78,37 @@ public class EndpointTest extends OpenSAMLTestBase {
     Assert.assertEquals(ep.getEndpointType(), ep2.getEndpointType());
     Assert.assertEquals(ep.getEntityID(), ep2.getEntityID());
     Assert.assertFalse(ep2.getSuspend());    
-  }  
+  }
+  
+  /**
+   * Tests the HideFromDiscovery-attribute
+   * 
+   * @throws Exception
+   */
+  @Test
+  public void testHideFromDiscoveryAttribute() throws Exception {
+    Endpoint ep = OpenSAMLTestBase.createSamlObject(Endpoint.class, Endpoint.DEFAULT_ELEMENT_NAME);
+    ep.setEndpointType(Endpoint.PROXY_SERVICE_ENDPOINT_TYPE);
+    ep.setEntityID("http://eidas.node.se");
+    ep.setHideFromDiscovery(true);
+    
+    Element element = OpenSAMLTestBase.marshall(ep);
+        
+    Endpoint ep2 = OpenSAMLTestBase.unmarshall(element, Endpoint.class);
+    Assert.assertEquals(ep.getEndpointType(), ep2.getEndpointType());
+    Assert.assertEquals(ep.getEntityID(), ep2.getEntityID());
+    Assert.assertTrue(ep2.getHideFromDiscovery());
+    
+    ep = OpenSAMLTestBase.createSamlObject(Endpoint.class, Endpoint.DEFAULT_ELEMENT_NAME);
+    ep.setEndpointType(Endpoint.PROXY_SERVICE_ENDPOINT_TYPE);
+    ep.setEntityID("http://eidas.node.se");
+    
+    element = OpenSAMLTestBase.marshall(ep);
+        
+    ep2 = OpenSAMLTestBase.unmarshall(element, Endpoint.class);
+    Assert.assertEquals(ep.getEndpointType(), ep2.getEndpointType());
+    Assert.assertEquals(ep.getEntityID(), ep2.getEntityID());
+    Assert.assertFalse(ep2.getHideFromDiscovery());
+  }
   
 }


### PR DESCRIPTION
An Endpoint now exposes the getHideFromDiscovery() method. This method
returns the value of the Swedish eID-specific attribute
“HideFromDiscovery”.