### PR TITLE
Add UTF-8 encoding to CurrentAddressTypeUnmarshaller

### DIFF
--- a/opensaml4/pom.xml
+++ b/opensaml4/pom.xml
@@ -6,7 +6,7 @@
   <groupId>se.litsec.eidas</groupId>
   <artifactId>eidas-opensaml4</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.2</version>
+  <version>2.1.3-SNAPSHOT</version>
 
   <name>eIDAS :: OpenSAML 4.X</name>
   <description>OpenSAML 4.X extension library for the eIDAS Framework</description>
@@ -105,6 +105,12 @@
         <artifactId>woodstox-core</artifactId>
         <version>6.4.0</version>
       </dependency>      
+      
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.6</version>
+      </dependency>
     
     </dependencies>  
   </dependencyManagement>  
@@ -126,7 +132,7 @@
     <dependency>
       <groupId>se.swedenconnect.opensaml</groupId>
       <artifactId>opensaml-security-ext</artifactId>
-      <version>[3.1.2,)</version>
+      <version>3.1.2</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/opensaml4/src/main/java/se/litsec/eidas/opensaml/ext/attributes/impl/CurrentAddressTypeUnmarshaller.java
+++ b/opensaml4/src/main/java/se/litsec/eidas/opensaml/ext/attributes/impl/CurrentAddressTypeUnmarshaller.java
@@ -17,6 +17,7 @@ package se.litsec.eidas.opensaml.ext.attributes.impl;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,7 +42,7 @@ import se.litsec.eidas.opensaml.ext.attributes.CurrentAddressType;
 
 /**
  * Thread safe unmarshaller for {@link CurrentAddressType}.
- * 
+ *
  * @author Martin Lindström (martin.lindstrom@litsec.se)
  */
 public class CurrentAddressTypeUnmarshaller extends CurrentAddressStructuredTypeUnmarshaller {
@@ -78,7 +79,7 @@ public class CurrentAddressTypeUnmarshaller extends CurrentAddressStructuredType
   /**
    * Parses the Base64-encoded contents of a {@code CurrentAddressType} element into the actual elements that this
    * encoding represents.
-   * 
+   *
    * @param node the text node to parse @param domElement the DOM element that we are unmarshalling @return a new DOM
    * document holding a clone of the {@code domElement} with its previous text node child replaced with the parsed
    * elements @throws UnmarshallingException for unmarshalling errors @throws
@@ -95,7 +96,7 @@ public class CurrentAddressTypeUnmarshaller extends CurrentAddressStructuredType
     //
     try {
       final byte[] bytes = Base64Support.decode(textContent);
-      final String addressElements = new String(bytes);
+      final String addressElements = new String(bytes, StandardCharsets.UTF_8);
 
       // Then build a fake XML document holding the contents in element form.
       //
@@ -159,7 +160,7 @@ public class CurrentAddressTypeUnmarshaller extends CurrentAddressStructuredType
   /**
    * Returns a map holding all registered namespace bindings, where the key is the qualified name of the namespace and
    * the value part is the URI.
-   * 
+   *
    * @param element
    *          the element to start from
    * @return a namespace map
@@ -172,7 +173,7 @@ public class CurrentAddressTypeUnmarshaller extends CurrentAddressStructuredType
 
   /**
    * Helper method to {@link #getNamespaceBindings(Element)}
-   * 
+   *
    * @param element
    *          the element to parse
    * @param namespaceMap


### PR DESCRIPTION
The unmarshaller for the `CurrentAddressType` does not use an explicit charset for decoding the Base64 byte array. Therefore, the charset of the operating system is used. Under Windows, this is unfortunately not UTF-8 by default, but for example Windows-1252. With this charset, some UTF-8 characters cannot be displayed correctly (ě, č, ß). The commit explicitly uses UTF-8 when creating the addressElement, just as it was previously used by the marshaller.
With this fix, there are no test errors in the Maven build even on systems without UTF-8 as the default character set, and special characters in the address are decoded as UTF-8 characters.